### PR TITLE
use rubocop action

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -38,6 +38,7 @@ jobs:
           reporter: github-pr-check # Default is github-pr-check
           skip_install: true
           use_bundler: true
+          rubocop_flags: "--display-only-fail-level-offenses"
       - name: Lint YAML files
         uses: karancode/yamllint-github-action@master
         with:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -17,7 +17,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  
+
 env:
   RAILS_ENV: test
   CI: true

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -14,24 +14,30 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: write
+  
 env:
   RAILS_ENV: test
   CI: true
 
 jobs:
   lint:
+    name: runner / rubocop
     runs-on: ubuntu-latest
-    continue-on-error: true
+    env:
+      BUNDLE_ONLY: rubocop
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Install Ruby and gems
-        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
         with:
           bundler-cache: true
-      - name: Lint Ruby files
-        run: bundle exec rubocop --display-only-fail-level-offenses
-
+      - uses: reviewdog/action-rubocop@v2
+        with:
+          reporter: github-pr-check # Default is github-pr-check
+          skip_install: true
+          use_bundler: true
       - name: Lint YAML files
         uses: karancode/yamllint-github-action@master
         with:
@@ -40,6 +46,17 @@ jobs:
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  analysis:
+    runs-on: ubuntu-latest
+    needs: lint
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+        with:
+          bundler-cache: true
       - name: Security audit dependencies
         continue-on-error: true
         run: bundle exec bundler-audit --update

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -15,6 +15,7 @@ tasks:
       bundle install &&
       yarn install
       gp sync-done installs
+      pip install yamllint
     openMode: split-left
   - name: create database & start server
     init: gp sync-await installs

--- a/Gemfile
+++ b/Gemfile
@@ -85,8 +85,12 @@ gem 'countries'
 # gem 'image_processing', '~> 1.2'
 
 # Performance optimization analysis
-gem 'rubocop'
-gem 'rubocop-performance', require: false
+#
+group :development, :rubocop, :test do
+  gem 'rubocop', require: false
+  gem 'rubocop-performance', require: false
+  gem 'rubocop-rails', require: false
+end
 
 gem 'autoprefixer-rails'
 gem 'font-awesome-sass', '~> 6.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -386,6 +386,11 @@ GEM
     rubocop-performance (1.21.0)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
+    rubocop-rails (2.25.1)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.33.0, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
     sassc (2.4.0)
@@ -502,6 +507,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   rubocop-performance
+  rubocop-rails
   sassc-rails
   selenium-webdriver
   simple_form!


### PR DESCRIPTION
# Description

Use [action-rubocop](https://github.com/reviewdog/action-rubocop) instead of manually running rubocop. This adds annotations to changed files, making it easier to find and fix the errors.